### PR TITLE
doc: specify event uri and streaming uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ builder.Services.AddControllers();
 // add FeatBit service
 builder.Services.AddFeatBit(options =>
 {
+    options.EventUri = new Uri("http://localhost:5100");
+    options.StreamingUri = new Uri("ws://localhost:5100");
     options.EnvSecret = "<replace-with-your-env-secret>";
     options.StartWaitTime = TimeSpan.FromSeconds(3);
 });

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Follow the documentation below to retrieve these values
 
 - [How to get the environment secret](https://docs.featbit.co/docs/sdk/faq#how-to-get-the-environment-secret)
 - [How to get the SDK URLs](https://docs.featbit.co/docs/sdk/faq#how-to-get-the-sdk-urls)
-  
+
 ### Quick Start
 
 The following code demonstrates basic usage of FeatBit.ServerSdk.
@@ -142,9 +142,9 @@ builder.Services.AddControllers();
 // add FeatBit service
 builder.Services.AddFeatBit(options =>
 {
-    options.EventUri = new Uri("http://localhost:5100");
-    options.StreamingUri = new Uri("ws://localhost:5100");
     options.EnvSecret = "<replace-with-your-env-secret>";
+    options.StreamingUri = new Uri("ws://localhost:5100");
+    options.EventUri = new Uri("http://localhost:5100");
     options.StartWaitTime = TimeSpan.FromSeconds(3);
 });
 


### PR DESCRIPTION
The first time I tried dependency injection without these two configurations, it gave me no warning, it just did not work.

I only found the error by examining the log.

So I think it's much better to add these two variables to the sample code.