### PR TITLE
refactor: reconnect even if we failed to start transport

### DIFF
--- a/examples/WebApiApp/Program.cs
+++ b/examples/WebApiApp/Program.cs
@@ -4,8 +4,11 @@ using FeatBit.Sdk.Server.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var consoleLogger = LoggerFactory.Create(x => x.AddConsole().SetMinimumLevel(LogLevel.Information));
+
 builder.Services.AddFeatBit(options =>
 {
+    options.LoggerFactory = consoleLogger;
     options.EnvSecret = "replace-with-your-env-secret";
     options.StartWaitTime = TimeSpan.FromSeconds(3);
 });

--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.Log.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.Log.cs
@@ -107,6 +107,11 @@ namespace FeatBit.Sdk.Server.Transport
 
             [LoggerMessage(28, LogLevel.Debug, "Failed to send message, transport state: {TransportState}", EventName = "FailedToSendMessage")]
             public static partial void FailedToSendMessage(ILogger logger, WebSocketState transportState);
+
+            [LoggerMessage(29, LogLevel.Warning,
+                "FbWebSocket closed abnormally with status: {Status}, description: {Description}.",
+                EventName = "AbnormallyClosed")]
+            public static partial void AbnormallyClosed(ILogger logger, WebSocketCloseStatus? status, string description);
         }
     }
 }

--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.Log.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.Log.cs
@@ -55,25 +55,23 @@ namespace FeatBit.Sdk.Server.Transport
             [LoggerMessage(14, LogLevel.Debug, "Stopping keep alive timer.", EventName = "StopKeepAliveTimer")]
             public static partial void StoppingKeepAliveTimer(ILogger logger);
 
-            [LoggerMessage(15, LogLevel.Error, "FbWebSocket reconnecting due to an error.",
+            [LoggerMessage(15, LogLevel.Warning, "FbWebSocket is trying to reconnect due to an exception. Flag evaluation results may be stale until reconnected.",
                 EventName = "ReconnectingWithError")]
             public static partial void ReconnectingWithError(ILogger logger, Exception exception);
 
-            [LoggerMessage(16, LogLevel.Information, "FbWebSocket reconnecting.", EventName = "Reconnecting")]
+            [LoggerMessage(16, LogLevel.Warning, "FbWebSocket is trying to reconnect. Flag evaluation results may be stale until reconnected.",
+                EventName = "Reconnecting")]
             public static partial void Reconnecting(ILogger logger);
 
-            [LoggerMessage(17, LogLevel.Trace,
-                "Connection met specified close status {CloseStatus}. Done reconnecting.",
-                EventName = "StopReconnectDueToSpecifiedCloseStatus")]
-            public static partial void StopReconnectDueToSpecifiedCloseStatus(ILogger logger,
-                WebSocketCloseStatus closeStatus);
+            [LoggerMessage(17, LogLevel.Warning, "Give up reconnecting due to the close status {CloseStatus}.",
+                EventName = "GiveUpReconnect")]
+            public static partial void GiveUpReconnect(ILogger logger, WebSocketCloseStatus? closeStatus);
 
-            [LoggerMessage(18, LogLevel.Trace, "Reconnect attempt number {RetryTimes} will start in {RetryDelay}.",
+            [LoggerMessage(18, LogLevel.Information, "Reconnect attempt number {RetryTimes} will start in {RetryDelay}.",
                 EventName = "AwaitingReconnectRetryDelay")]
-            public static partial void
-                AwaitingReconnectRetryDelay(ILogger logger, long retryTimes, TimeSpan retryDelay);
+            public static partial void AwaitingReconnectRetryDelay(ILogger logger, long retryTimes, TimeSpan retryDelay);
 
-            [LoggerMessage(19, LogLevel.Trace, "Connection stopped during reconnect delay. Done reconnecting.",
+            [LoggerMessage(19, LogLevel.Warning, "Connection stopped during reconnect delay. Done reconnecting.",
                 EventName = "ReconnectingStoppedDuringRetryDelay")]
             public static partial void ReconnectingStoppedDuringRetryDelay(ILogger logger);
 
@@ -82,10 +80,10 @@ namespace FeatBit.Sdk.Server.Transport
                 EventName = "Reconnected")]
             public static partial void Reconnected(ILogger logger, long retryTimes, TimeSpan elapsedTime);
 
-            [LoggerMessage(21, LogLevel.Trace, "Reconnect attempt failed.", EventName = "ReconnectAttemptFailed")]
+            [LoggerMessage(21, LogLevel.Debug, "Reconnect attempt failed.", EventName = "ReconnectAttemptFailed")]
             public static partial void ReconnectAttemptFailed(ILogger logger, Exception exception);
 
-            [LoggerMessage(22, LogLevel.Trace, "Connection stopped during reconnect attempt. Done reconnecting.",
+            [LoggerMessage(22, LogLevel.Warning, "Connection stopped during reconnect attempt. Done reconnecting.",
                 EventName = "ReconnectingStoppedDuringReconnectAttempt")]
             public static partial void ReconnectingStoppedDuringReconnectAttempt(ILogger logger);
 
@@ -104,8 +102,8 @@ namespace FeatBit.Sdk.Server.Transport
                 EventName = "WaitingForReceiveLoopToTerminate")]
             public static partial void WaitingForReceiveLoopToTerminate(ILogger logger);
 
-            [LoggerMessage(27, LogLevel.Information, "FbWebSocket closed.", EventName = "Closed")]
-            public static partial void Closed(ILogger logger);
+            [LoggerMessage(27, LogLevel.Information, "FbWebSocket closed. Status: {CloseStatus}.", EventName = "Closed")]
+            public static partial void Closed(ILogger logger, WebSocketCloseStatus? closeStatus);
 
             [LoggerMessage(28, LogLevel.Debug, "Failed to send message, transport state: {TransportState}", EventName = "FailedToSendMessage")]
             public static partial void FailedToSendMessage(ILogger logger, WebSocketState transportState);

--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
@@ -70,6 +70,7 @@ namespace FeatBit.Sdk.Server.Transport
                 throw new InvalidOperationException("Configured WebSocketTransportFactory did not return a value.");
             }
 
+            _transport = transport;
             try
             {
                 // starts the transport
@@ -82,14 +83,13 @@ namespace FeatBit.Sdk.Server.Transport
                 if (!isReconnecting)
                 {
                     Log.ErrorStartingTransport(_logger, ex);
+
+                    // reconnect if we failed to start the transport
+                    _ = ReconnectAsync();
                 }
 
-                await transport.StopAsync();
                 throw;
             }
-
-            // We successfully started, set the transport properties (we don't want to set these until the transport is definitely running).
-            _transport = transport;
 
             Log.StartingReceiveLoop(_logger);
             _receiveTask = ReceiveLoop();
@@ -206,6 +206,7 @@ namespace FeatBit.Sdk.Server.Transport
             }
             else
             {
+                Log.GiveUpReconnect(_logger, _transport.CloseStatus);
                 CompleteClose(_closeException);
             }
         }
@@ -236,7 +237,7 @@ namespace FeatBit.Sdk.Server.Transport
             {
                 if (!ShouldReconnect())
                 {
-                    Log.StopReconnectDueToSpecifiedCloseStatus(_logger, _transport.CloseStatus!.Value);
+                    Log.GiveUpReconnect(_logger, _transport.CloseStatus);
                     CompleteClose(_closeException);
                     return;
                 }
@@ -259,7 +260,7 @@ namespace FeatBit.Sdk.Server.Transport
 
                 try
                 {
-                    await ConnectAsync(_stopCts.Token, true).ConfigureAwait(false);
+                    await ConnectAsync(_stopCts.Token, isReconnecting: true).ConfigureAwait(false);
 
                     Log.Reconnected(_logger, retryTimes, DateTime.UtcNow - reconnectStartTime);
 
@@ -304,7 +305,7 @@ namespace FeatBit.Sdk.Server.Transport
 
             Log.InvokingEventHandler(_logger, nameof(OnClosed));
             _ = OnClosed?.Invoke(exception, _transport.CloseStatus, _transport.CloseDescription).ConfigureAwait(false);
-            Log.Closed(_logger);
+            Log.Closed(_logger, _transport.CloseStatus);
         }
 
         private async Task KeepAliveAsync(CancellationToken ct = default)
@@ -342,8 +343,8 @@ namespace FeatBit.Sdk.Server.Transport
                 await (_receiveTask ?? Task.CompletedTask).ConfigureAwait(false);
             }
 
+            Log.Closed(_logger, _transport?.CloseStatus);
             _transport = null;
-            Log.Closed(_logger);
         }
     }
 }

--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
@@ -206,7 +206,6 @@ namespace FeatBit.Sdk.Server.Transport
             }
             else
             {
-                Log.GiveUpReconnect(_logger, _transport.CloseStatus);
                 CompleteClose(_closeException);
             }
         }
@@ -305,7 +304,11 @@ namespace FeatBit.Sdk.Server.Transport
 
             Log.InvokingEventHandler(_logger, nameof(OnClosed));
             _ = OnClosed?.Invoke(exception, _transport.CloseStatus, _transport.CloseDescription).ConfigureAwait(false);
-            Log.Closed(_logger, _transport.CloseStatus);
+
+            if (_transport.CloseStatus.HasValue && _transport.CloseStatus != WebSocketCloseStatus.NormalClosure)
+            {
+                Log.AbnormallyClosed(_logger, _transport.CloseStatus, _transport.CloseDescription);
+            }
         }
 
         private async Task KeepAliveAsync(CancellationToken ct = default)

--- a/src/FeatBit.ServerSdk/Transport/WebSocketTransport.cs
+++ b/src/FeatBit.ServerSdk/Transport/WebSocketTransport.cs
@@ -74,17 +74,17 @@ namespace FeatBit.Sdk.Server.Transport
             // - subscribe to incoming messages from the caller
             // - proxy incoming data from the websocket back to the subscriber
             _application = pair.Application;
-            
-            var factory = _webSocketFactory ?? DefaultWebSocketFactory;
 
+            var factory = _webSocketFactory ?? DefaultWebSocketFactory;
             _webSocket = await factory(uri, cancellationToken);
             if (_webSocket == null)
             {
                 throw new InvalidOperationException("Configured WebSocketFactory did not return a value.");
             }
-            Log.StartedTransport(_logger);
-            
+
             Running = ProcessSocketAsync(_webSocket);
+
+            Log.StartedTransport(_logger);
         }
 
         private static async Task<WebSocket> DefaultWebSocketFactory(Uri uri, CancellationToken cancellationToken)

--- a/src/FeatBit.ServerSdk/Transport/WebSocketTransport.cs
+++ b/src/FeatBit.ServerSdk/Transport/WebSocketTransport.cs
@@ -62,16 +62,6 @@ namespace FeatBit.Sdk.Server.Transport
         {
             _closeTimeout = closeTimeout ?? DefaultCloseTimeout;
 
-            var factory = _webSocketFactory ?? DefaultWebSocketFactory;
-
-            _webSocket = await factory(uri, cancellationToken);
-            if (_webSocket == null)
-            {
-                throw new InvalidOperationException("Configured WebSocketFactory did not return a value.");
-            }
-
-            Log.StartedTransport(_logger);
-
             // Create the pipe pair (Application's writer is connected to Transport's reader, and vice versa)
             var pair = DuplexPipe.CreateConnectionPair(DefaultPipeOptions, DefaultPipeOptions);
 
@@ -84,6 +74,16 @@ namespace FeatBit.Sdk.Server.Transport
             // - subscribe to incoming messages from the caller
             // - proxy incoming data from the websocket back to the subscriber
             _application = pair.Application;
+            
+            var factory = _webSocketFactory ?? DefaultWebSocketFactory;
+
+            _webSocket = await factory(uri, cancellationToken);
+            if (_webSocket == null)
+            {
+                throw new InvalidOperationException("Configured WebSocketFactory did not return a value.");
+            }
+            Log.StartedTransport(_logger);
+            
             Running = ProcessSocketAsync(_webSocket);
         }
 


### PR DESCRIPTION
We should try to reconnect even we failed to start initially.

fixed #11 

Example running log

```log
info: FeatBit.Sdk.Server.FbClient[0]
      Starting FbClient...
info: FeatBit.Sdk.Server.FbClient[0]
      Waiting up to 3000 milliseconds for FbClient to start...
fail: FeatBit.Sdk.Server.FbClient[0]
      FbClient failed to start successfully within 3000 milliseconds. This error usually indicates a connection issue with FeatBit or an invalid secret. Please double-check your EnvSecret and StreamingUri configuration.
warn: FeatBit.Sdk.Server.Transport.FbWebSocket[16]
      FbWebSocket is trying to reconnect. Flag evaluation results may be stale until reconnected.
info: FeatBit.Sdk.Server.Transport.FbWebSocket[18]
      Reconnect attempt number 0 will start in 00:00:00.
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://localhost:5014
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\Work\featbit-sdks\dotnet-server-sdk\examples\WebApiApp\
info: FeatBit.Sdk.Server.Transport.FbWebSocket[18]
      Reconnect attempt number 1 will start in 00:00:01.
info: FeatBit.Sdk.Server.Transport.FbWebSocket[18]
      Reconnect attempt number 2 will start in 00:00:02.
info: FeatBit.Sdk.Server.Transport.FbWebSocket[18]
      Reconnect attempt number 3 will start in 00:00:03.
info: FeatBit.Sdk.Server.Transport.FbWebSocket[7]
      FbWebSocket started.
info: FeatBit.Sdk.Server.Transport.FbWebSocket[20]
      FbWebSocket reconnected successfully after 3 attempts and 00:00:19.6971031 elapsed.
```