### PR TITLE
fix: UriBuilder behaves differently on .NET Framework and .NET Core

### DIFF
--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
@@ -119,7 +119,7 @@ namespace FeatBit.Sdk.Server.Transport
             var webSocketUri = new UriBuilder(options.StreamingUri)
             {
                 Path = "streaming",
-                Query = $"?type=server&token={token}"
+                Query = $"type=server&token={token}"
             }.Uri;
 
             return webSocketUri;


### PR DESCRIPTION
In .NET Framework, the [UriBuilder.Query](https://learn.microsoft.com/en-us/dotnet/api/system.uribuilder.query#system-uribuilder-query) property always prepend a `?` character. Starting in .NET Core 1.0, this property no longer prepend `?` characters to the stored value if one is already present at the beginning of the string.

**Reference**

- https://learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core#uribuilder-properties-no-longer-prepend-leading-characters