### PR TITLE
fix: Apply relative path for EventUri and StreamingUri

### DIFF
--- a/src/FeatBit.ServerSdk/Events/DefaultEventSender.cs
+++ b/src/FeatBit.ServerSdk/Events/DefaultEventSender.cs
@@ -37,7 +37,7 @@ namespace FeatBit.Sdk.Server.Events
             _httpClient = httpClient ?? NewHttpClient();
             AddDefaultHeaders(options);
 
-            _eventUri = new Uri(options.EventUri, EventPath);
+            _eventUri = new Uri(options.EventUri, $"{options.EventUri.LocalPath.TrimEnd('/')}{EventPath}");
             _maxAttempts = options.MaxSendEventAttempts;
             _retryInterval = options.SendEventRetryInterval;
 

--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
@@ -118,7 +118,7 @@ namespace FeatBit.Sdk.Server.Transport
             var token = ConnectionToken.New(options.EnvSecret);
             var webSocketUri = new UriBuilder(options.StreamingUri)
             {
-                Path = "streaming",
+                Path = $"{options.StreamingUri.LocalPath.TrimEnd('/')}/streaming",
                 Query = $"type=server&token={token}"
             }.Uri;
 


### PR DESCRIPTION
Hi!

I've found that current solution will not work with FeatBit hosted under non-root host.
Example: 
Host set in config `https://contoso.com/featbit` will not work, and will try to send all requests to `https://contoso.com/streaming` instead of `https://contoso.com/featbit/streaming`.

This is a bit naive fix, but it will allow me to use FeatBit with my deployments