### PR TITLE
feat: add client status

### DIFF
--- a/examples/WebApiApp/FeatBitHealthCheck.cs
+++ b/examples/WebApiApp/FeatBitHealthCheck.cs
@@ -1,0 +1,30 @@
+using FeatBit.Sdk.Server;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace WebApiApp;
+
+public class FeatBitHealthCheck : IHealthCheck
+{
+    private readonly IFbClient _fbClient;
+
+    public FeatBitHealthCheck(IFbClient fbClient)
+    {
+        _fbClient = fbClient;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var status = _fbClient.Status;
+
+        var result = status switch
+        {
+            FbClientStatus.Ready => HealthCheckResult.Healthy(),
+            FbClientStatus.Stale => HealthCheckResult.Degraded(),
+            _ => HealthCheckResult.Unhealthy()
+        };
+
+        return Task.FromResult(result);
+    }
+}

--- a/examples/WebApiApp/Program.cs
+++ b/examples/WebApiApp/Program.cs
@@ -1,6 +1,9 @@
 using FeatBit.Sdk.Server;
 using FeatBit.Sdk.Server.Model;
 using FeatBit.Sdk.Server.DependencyInjection;
+using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using WebApiApp;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +16,15 @@ builder.Services.AddFeatBit(options =>
     options.StartWaitTime = TimeSpan.FromSeconds(3);
 });
 
+builder.Services.AddHealthChecks()
+    .AddCheck<FeatBitHealthCheck>("FeatBit");
+
 var app = builder.Build();
+
+app.MapHealthChecks("/healthz", new HealthCheckOptions
+{
+    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+});
 
 // curl -X GET --location "http://localhost:5014/variation-detail/game-runner?fallbackValue=lol"
 app.MapGet("/variation-detail/{flagKey}", (IFbClient fbClient, string flagKey, string fallbackValue) =>

--- a/examples/WebApiApp/WebApiApp.csproj
+++ b/examples/WebApiApp/WebApiApp.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="FeatBit.ServerSdk" Version="1.1.4"/>
+        <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5"/>
     </ItemGroup>
 
     <!--

--- a/examples/WebApiApp/WebApiApp.csproj
+++ b/examples/WebApiApp/WebApiApp.csproj
@@ -7,14 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FeatBit.ServerSdk" Version="1.1.4"/>
+        <!--        <PackageReference Include="FeatBit.ServerSdk" Version="1.1.4"/>-->
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5"/>
     </ItemGroup>
 
-    <!--
-        <ItemGroup>
-            <ProjectReference Include="..\..\src\FeatBit.ServerSdk\FeatBit.ServerSdk.csproj"/>
-        </ItemGroup>
-    -->
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\FeatBit.ServerSdk\FeatBit.ServerSdk.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/src/FeatBit.ServerSdk/Concurrent/AtomicBoolean.cs
+++ b/src/FeatBit.ServerSdk/Concurrent/AtomicBoolean.cs
@@ -10,7 +10,7 @@ namespace FeatBit.Sdk.Server.Concurrent
     /// without any explicit locking. .NET's strong memory on write guarantees might already enforce
     /// this ordering, but the addition of the MemoryBarrier guarantees it.
     /// </summary>
-    public class AtomicBoolean
+    public sealed class AtomicBoolean
     {
         private const int FalseValue = 0;
         private const int TrueValue = 1;

--- a/src/FeatBit.ServerSdk/Concurrent/StatusManager.cs
+++ b/src/FeatBit.ServerSdk/Concurrent/StatusManager.cs
@@ -26,6 +26,20 @@ public sealed class StatusManager<TStatus> where TStatus : Enum
         }
     }
 
+    public bool CompareAndSet(TStatus expected, TStatus newStatus)
+    {
+        lock (_statusLock)
+        {
+            if (!EqualityComparer<TStatus>.Default.Equals(_status, expected))
+            {
+                return false;
+            }
+
+            SetStatus(newStatus);
+            return true;
+        }
+    }
+
     public void SetStatus(TStatus newStatus)
     {
         lock (_statusLock)

--- a/src/FeatBit.ServerSdk/Concurrent/StatusManager.cs
+++ b/src/FeatBit.ServerSdk/Concurrent/StatusManager.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace FeatBit.Sdk.Server.Concurrent;
+
+public sealed class StatusManager<TStatus> where TStatus : Enum
+{
+    private TStatus _status;
+    private readonly object _statusLock = new object();
+    private readonly Action<TStatus> _onStatusChanged;
+
+    public StatusManager(TStatus initialStatus, Action<TStatus> onStatusChanged = null)
+    {
+        _status = initialStatus;
+        _onStatusChanged = onStatusChanged;
+    }
+
+    public TStatus Status
+    {
+        get
+        {
+            lock (_statusLock)
+            {
+                return _status;
+            }
+        }
+    }
+
+    public void SetStatus(TStatus newStatus)
+    {
+        lock (_statusLock)
+        {
+            if (EqualityComparer<TStatus>.Default.Equals(_status, newStatus))
+            {
+                return;
+            }
+
+            _status = newStatus;
+            _onStatusChanged?.Invoke(_status);
+        }
+    }
+}

--- a/src/FeatBit.ServerSdk/DataSynchronizer/DataSynchronizerStatus.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/DataSynchronizerStatus.cs
@@ -1,0 +1,45 @@
+namespace FeatBit.Sdk.Server.DataSynchronizer;
+
+public enum DataSynchronizerStatus
+{
+    /// <summary>
+    /// The initial state of the synchronizer when the SDK is being initialized.
+    /// </summary>
+    /// <remarks>
+    /// If it encounters an error that requires it to retry initialization, the state will remain at
+    /// <see cref="Starting"/> until it either succeeds and becomes <see cref="Stable"/>, or
+    /// permanently fails and becomes <see cref="Stopped"/>.
+    /// </remarks>
+    Starting,
+
+    /// <summary>
+    /// Indicates that the synchronizer is currently operational and has not had any problems since the
+    /// last time it received data.
+    /// </summary>
+    /// <remarks>
+    /// In streaming mode, this means that there is currently an open stream connection and that at least
+    /// one initial message has been received on the stream. In polling mode, it means that the last poll
+    /// request succeeded.
+    /// </remarks>
+    Stable,
+
+    /// <summary>
+    /// Indicates that the synchronizer encountered an error that it will attempt to recover from.
+    /// </summary>
+    /// <remarks>
+    /// In streaming mode, this means that the stream connection failed, or had to be dropped due to some
+    /// other error, and will be retried after a backoff delay. In polling mode, it means that the last poll
+    /// request failed, and a new poll request will be made after the configured polling interval.
+    /// </remarks>
+    Interrupted,
+
+    /// <summary>
+    /// Indicates that the synchronizer has been permanently shut down.
+    /// </summary>
+    /// <remarks>
+    /// This could be because it encountered an unrecoverable error (for instance, the Evaluation server
+    /// rejected the SDK key: an invalid SDK key will never become valid), or because the SDK client was
+    /// explicitly shut down.
+    /// </remarks>
+    Stopped
+}

--- a/src/FeatBit.ServerSdk/DataSynchronizer/IDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/IDataSynchronizer.cs
@@ -23,8 +23,7 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
         /// to change.
         /// </para>
         /// <para>
-        /// Notifications will be dispatched on a background task. It is the listener's responsibility to return
-        /// as soon as possible so as not to block subsequent notifications.
+        /// The listener should return as soon as possible so as not to block subsequent notifications.
         /// </para>
         /// </remarks>
         event Action<DataSynchronizerStatus> StatusChanged;

--- a/src/FeatBit.ServerSdk/DataSynchronizer/IDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/IDataSynchronizer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace FeatBit.Sdk.Server.DataSynchronizer
@@ -8,6 +9,25 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
         /// Indicates whether the data synchronizer has finished initializing.
         /// </summary>
         public bool Initialized { get; }
+
+        /// <summary>
+        /// The current status of the data synchronizer.
+        /// </summary>
+        public DataSynchronizerStatus Status { get; }
+
+        /// <summary>An event for receiving notifications of status changes.</summary>
+        /// <remarks>
+        /// <para>
+        /// Any handlers attached to this event will be notified whenever any property of the status has changed.
+        /// See <see cref="T:FeatBit.Sdk.Server.DataSynchronizer.DataSynchronizerStatus" /> for an explanation of the meaning of each property and what could cause it
+        /// to change.
+        /// </para>
+        /// <para>
+        /// Notifications will be dispatched on a background task. It is the listener's responsibility to return
+        /// as soon as possible so as not to block subsequent notifications.
+        /// </para>
+        /// </remarks>
+        event Action<DataSynchronizerStatus> StatusChanged;
 
         /// <summary>
         /// Starts the data synchronizer. This is called once from the <see cref="FbClient"/> constructor.

--- a/src/FeatBit.ServerSdk/DataSynchronizer/NullDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/NullDataSynchronizer.cs
@@ -1,18 +1,36 @@
+using System;
 using System.Threading.Tasks;
+using FeatBit.Sdk.Server.Concurrent;
 
 namespace FeatBit.Sdk.Server.DataSynchronizer;
 
 internal sealed class NullDataSynchronizer : IDataSynchronizer
 {
+    private readonly StatusManager<DataSynchronizerStatus> _statusManager;
+
     public bool Initialized => true;
+    public DataSynchronizerStatus Status => _statusManager.Status;
+    public event Action<DataSynchronizerStatus> StatusChanged;
+
+    public NullDataSynchronizer()
+    {
+        _statusManager = new StatusManager<DataSynchronizerStatus>(
+            DataSynchronizerStatus.Stable,
+            OnStatusChanged
+        );
+    }
 
     public Task<bool> StartAsync()
     {
+        _statusManager.SetStatus(DataSynchronizerStatus.Stable);
         return Task.FromResult(true);
     }
 
     public Task StopAsync()
     {
+        _statusManager.SetStatus(DataSynchronizerStatus.Stopped);
         return Task.CompletedTask;
     }
+
+    private void OnStatusChanged(DataSynchronizerStatus status) => StatusChanged?.Invoke(status);
 }

--- a/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
@@ -194,12 +194,14 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
 
         public async Task StopAsync()
         {
-            await _webSocket.CloseAsync();
-
             _webSocket.OnConnected -= OnConnected;
             _webSocket.OnReceived -= OnReceived;
             _webSocket.OnReconnecting -= OnReconnecting;
             _webSocket.OnClosed -= OnClosed;
+
+            await _webSocket.CloseAsync();
+
+            _statusManager.SetStatus(DataSynchronizerStatus.Stopped);
         }
     }
 }

--- a/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
@@ -83,7 +83,6 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
             {
                 // do data-sync once the connection is established
                 await DoDataSyncAsync();
-                _statusManager.SetStatus(DataSynchronizerStatus.Stable);
             }
             catch (Exception ex)
             {
@@ -96,6 +95,7 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
             try
             {
                 HandleMessage(bytes);
+                _statusManager.SetStatus(DataSynchronizerStatus.Stable);
             }
             catch (Exception ex)
             {
@@ -194,13 +194,13 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
 
         public async Task StopAsync()
         {
+            await _webSocket.CloseAsync();
+
             _webSocket.OnConnected -= OnConnected;
             _webSocket.OnReceived -= OnReceived;
             _webSocket.OnReconnecting -= OnReconnecting;
             _webSocket.OnReconnected -= OnReconnected;
             _webSocket.OnClosed -= OnClosed;
-
-            await _webSocket.CloseAsync();
         }
     }
 }

--- a/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
@@ -105,7 +105,7 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
 
         private Task OnReconnecting(Exception ex)
         {
-            _statusManager.SetStatus(DataSynchronizerStatus.Interrupted);
+            _statusManager.CompareAndSet(DataSynchronizerStatus.Stable, DataSynchronizerStatus.Interrupted);
             return Task.CompletedTask;
         }
 

--- a/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
@@ -52,7 +52,6 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
             _webSocket.OnConnected += OnConnected;
             _webSocket.OnReceived += OnReceived;
             _webSocket.OnReconnecting += OnReconnecting;
-            _webSocket.OnReconnected += OnReconnected;
             _webSocket.OnClosed += OnClosed;
 
             _initTcs = new TaskCompletionSource<bool>();
@@ -108,12 +107,6 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
         private Task OnReconnecting(Exception ex)
         {
             _statusManager.SetStatus(DataSynchronizerStatus.Interrupted);
-            return Task.CompletedTask;
-        }
-
-        private Task OnReconnected()
-        {
-            _statusManager.SetStatus(DataSynchronizerStatus.Stable);
             return Task.CompletedTask;
         }
 
@@ -199,7 +192,6 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
             _webSocket.OnConnected -= OnConnected;
             _webSocket.OnReceived -= OnReceived;
             _webSocket.OnReconnecting -= OnReconnecting;
-            _webSocket.OnReconnected -= OnReconnected;
             _webSocket.OnClosed -= OnClosed;
         }
     }

--- a/src/FeatBit.ServerSdk/FbClient.cs
+++ b/src/FeatBit.ServerSdk/FbClient.cs
@@ -77,10 +77,10 @@ namespace FeatBit.Sdk.Server
         /// </para>
         /// <list type="number">
         /// <item><description> It has successfully connected to FeatBit and received feature flag data. In this
-        /// case, <see cref="Initialized"/> will be true. </description></item>
+        /// case, <see cref="Initialized"/> will be true and the <see cref="Status"/> will be <see cref="FbClientStatus.Ready"/>. </description></item>
         /// <item><description> It has not succeeded in connecting within the <see cref="FbOptionsBuilder.StartWaitTime(TimeSpan)"/>
         /// timeout (the default for this is 3 seconds). This could happen due to a network problem or a
-        /// temporary service outage. In this case, <see cref="Initialized"/> will be false, 
+        /// temporary service outage. In this case, <see cref="Initialized"/> will be false, and the <see cref="Status"/> will be <see cref="FbClientStatus.NotReady"/>,
         /// indicating that the SDK will still continue trying to connect in the background. </description></item>
         /// <item><description> It has encountered an unrecoverable error: for instance, FeatBit has rejected the
         /// sdk secret. Since an invalid key will not become valid, the SDK will not retry in this case.

--- a/src/FeatBit.ServerSdk/FbClient.cs
+++ b/src/FeatBit.ServerSdk/FbClient.cs
@@ -126,6 +126,7 @@ namespace FeatBit.Sdk.Server
                 _dataSynchronizer = new WebSocketDataSynchronizer(options, _store);
                 _eventProcessor = new DefaultEventProcessor(options);
             }
+
             _dataSynchronizer.StatusChanged += OnDataSynchronizerStatusChanged;
 
             _logger = options.LoggerFactory.CreateLogger<FbClient>();
@@ -142,13 +143,16 @@ namespace FeatBit.Sdk.Server
             IEventProcessor eventProcessor)
         {
             _options = options;
+            _statusManager = new StatusManager<FbClientStatus>(FbClientStatus.NotReady);
+
             _store = store;
+            _evaluator = new Evaluator(_store);
+
             _dataSynchronizer = synchronizer;
             _dataSynchronizer.StatusChanged += OnDataSynchronizerStatusChanged;
-            _evaluator = new Evaluator(_store);
             _eventProcessor = eventProcessor;
+
             _logger = options.LoggerFactory.CreateLogger<FbClient>();
-            _statusManager = new StatusManager<FbClientStatus>(FbClientStatus.NotReady);
 
             // starts client
             Start();

--- a/src/FeatBit.ServerSdk/FbClientStatus.cs
+++ b/src/FeatBit.ServerSdk/FbClientStatus.cs
@@ -18,7 +18,7 @@ public enum FbClientStatus
     Stale,
 
     /// <summary>
-    /// FbClient has entered an irrecoverable error state.
+    /// FbClient has entered an irrecoverable error state or has been explicitly shut down.
     /// </summary>
-    Fatal
+    Closed
 }

--- a/src/FeatBit.ServerSdk/FbClientStatus.cs
+++ b/src/FeatBit.ServerSdk/FbClientStatus.cs
@@ -1,0 +1,24 @@
+namespace FeatBit.Sdk.Server;
+
+public enum FbClientStatus
+{
+    /// <summary>
+    /// FbClient has not been initialized and cannot yet evaluate flags.
+    /// </summary>
+    NotReady,
+
+    /// <summary>
+    /// FbClient is ready to resolve flags.
+    /// </summary>
+    Ready,
+
+    /// <summary>
+    /// FbClient's cached data may not be up-to-date with the source of truth.
+    /// </summary>
+    Stale,
+
+    /// <summary>
+    /// FbClient has entered an irrecoverable error state.
+    /// </summary>
+    Fatal
+}

--- a/src/FeatBit.ServerSdk/IFbClient.cs
+++ b/src/FeatBit.ServerSdk/IFbClient.cs
@@ -15,6 +15,11 @@ public interface IFbClient
     bool Initialized { get; }
 
     /// <summary>
+    /// Indicates the current status of the client.
+    /// </summary>
+    FbClientStatus Status { get; }
+
+    /// <summary>
     /// Calculates the boolean value of a feature flag for a given user.
     /// </summary>
     /// <remarks>

--- a/tests/FeatBit.ServerSdk.Tests/Concurrent/AtomicBooleanTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/Concurrent/AtomicBooleanTests.cs
@@ -1,0 +1,55 @@
+namespace FeatBit.Sdk.Server.Concurrent;
+
+public class AtomicBooleanTests
+{
+    [Fact]
+    public void SetInitialValue()
+    {
+        var trueBoolean = new AtomicBoolean(true);
+        Assert.True(trueBoolean.Value);
+
+        var falseBoolean = new AtomicBoolean(false);
+        Assert.False(falseBoolean.Value);
+    }
+
+    [Fact]
+    public void CompareAndSetWhenMatch()
+    {
+        var atomicBoolean = new AtomicBoolean(true);
+
+        var newValueSet = atomicBoolean.CompareAndSet(true, false);
+
+        Assert.True(newValueSet);
+        Assert.False(atomicBoolean.Value);
+    }
+
+    [Fact]
+    public void CompareAndSetWhenNotMatch()
+    {
+        var atomicBoolean = new AtomicBoolean(true);
+
+        var newValueSet = atomicBoolean.CompareAndSet(false, false);
+
+        Assert.False(newValueSet);
+        Assert.True(atomicBoolean.Value);
+    }
+
+    [Fact]
+    public void GetAndSet()
+    {
+        var atomicBoolean = new AtomicBoolean(true);
+
+        var oldValue = atomicBoolean.GetAndSet(false);
+
+        Assert.False(atomicBoolean.Value);
+        Assert.True(oldValue);
+    }
+
+    [Fact]
+    public void CastToBool()
+    {
+        var atomicBoolean = new AtomicBoolean(true);
+        bool boolValue = atomicBoolean;
+        Assert.True(boolValue);
+    }
+}

--- a/tests/FeatBit.ServerSdk.Tests/Concurrent/StatusManagerTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/Concurrent/StatusManagerTests.cs
@@ -38,4 +38,16 @@ public class StatusManagerTests
 
         Assert.Equal(changed, eventTriggered);
     }
+
+    [Theory]
+    [InlineData(TestStatus.A, TestStatus.B, true)]
+    [InlineData(TestStatus.B, TestStatus.A, false)]
+    public void CompareAndSetStatus(TestStatus expected, TestStatus newStatus, bool setSuccess)
+    {
+        var statusManager = new StatusManager<TestStatus>(TestStatus.A);
+        var compareAndSetSuccess = statusManager.CompareAndSet(expected, newStatus);
+
+        Assert.Equal(setSuccess, compareAndSetSuccess);
+        Assert.Equal(newStatus, statusManager.Status);
+    }
 }

--- a/tests/FeatBit.ServerSdk.Tests/Concurrent/StatusManagerTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/Concurrent/StatusManagerTests.cs
@@ -1,0 +1,41 @@
+namespace FeatBit.Sdk.Server.Concurrent;
+
+public class StatusManagerTests
+{
+    public enum TestStatus
+    {
+        A,
+        B
+    }
+
+    [Fact]
+    public void SetInitialStatus()
+    {
+        var statusManager = new StatusManager<TestStatus>(TestStatus.A);
+        Assert.Equal(TestStatus.A, statusManager.Status);
+    }
+
+    [Fact]
+    public void ChangesStatus()
+    {
+        var statusManager = new StatusManager<TestStatus>(TestStatus.A);
+        statusManager.SetStatus(TestStatus.B);
+        Assert.Equal(TestStatus.B, statusManager.Status);
+    }
+
+    [Theory]
+    [InlineData(TestStatus.A, TestStatus.B, true)]
+    [InlineData(TestStatus.A, TestStatus.A, false)]
+    public void TriggerIfStatusChangedEvent(TestStatus old, TestStatus @new, bool changed)
+    {
+        var eventTriggered = false;
+        var statusManager = new StatusManager<TestStatus>(old, newStatus =>
+        {
+            Assert.Equal(newStatus, @new);
+            eventTriggered = true;
+        });
+        statusManager.SetStatus(@new);
+
+        Assert.Equal(changed, eventTriggered);
+    }
+}

--- a/tests/FeatBit.ServerSdk.Tests/DataSynchronizer/WebSocketDataSynchronizerTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/DataSynchronizer/WebSocketDataSynchronizerTests.cs
@@ -91,6 +91,7 @@ public class WebSocketDataSynchronizerTests
     public async Task ServerDisconnectedAfterStable()
     {
         var options = new FbOptionsBuilder()
+            .ReconnectRetryDelays(new[] { TimeSpan.FromMilliseconds(200) })
             .Build();
         var store = new DefaultMemoryStore();
 

--- a/tests/FeatBit.ServerSdk.Tests/DataSynchronizer/WebSocketDataSynchronizerTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/DataSynchronizer/WebSocketDataSynchronizerTests.cs
@@ -30,6 +30,7 @@ public class WebSocketDataSynchronizerTests
 
         Assert.True(store.Populated);
         Assert.True(synchronizer.Initialized);
+        Assert.True(synchronizer.Status == DataSynchronizerStatus.Stable);
 
         var flag = store.Get<FeatureFlag>("ff_returns-true");
         Assert.NotNull(flag);
@@ -55,6 +56,7 @@ public class WebSocketDataSynchronizerTests
         await startTask.WaitAsync(options.StartWaitTime);
 
         Assert.True(synchronizer.Initialized);
+        Assert.True(synchronizer.Status == DataSynchronizerStatus.Stable);
 
         var flag = store.Get<FeatureFlag>("ff_returns-true");
         Assert.NotNull(flag);

--- a/tests/FeatBit.ServerSdk.Tests/TestApp.cs
+++ b/tests/FeatBit.ServerSdk.Tests/TestApp.cs
@@ -54,6 +54,11 @@ public class TestApp : WebApplicationFactory<TestStartup>
         return new FbWebSocket(options, CreateWebSocketTransport);
     }
 
+    internal FbWebSocket CreateFbWebSocket(FbOptions options, Uri webSocketUri)
+    {
+        return new FbWebSocket(options, CreateWebSocketTransport, _ => webSocketUri);
+    }
+
     protected override TestServer CreateServer(IWebHostBuilder builder) =>
         base.CreateServer(builder.UseSolutionRelativeContentRoot(""));
 

--- a/tests/FeatBit.ServerSdk.Tests/TestStartup.cs
+++ b/tests/FeatBit.ServerSdk.Tests/TestStartup.cs
@@ -108,6 +108,7 @@ public class TestStartup : StartupBase
 
                     if (token == "close-after-first-datasync")
                     {
+                        await Task.Delay(100);
                         await webSocket.CloseOutputAsync(
                             WebSocketCloseStatus.EndpointUnavailable,
                             "server goes down",

--- a/tests/FeatBit.ServerSdk.Tests/TestStartup.cs
+++ b/tests/FeatBit.ServerSdk.Tests/TestStartup.cs
@@ -105,6 +105,15 @@ public class TestStartup : StartupBase
                     var response = timestamp == 0 ? TestData.FullDataSet : TestData.PatchDataSet;
 
                     await webSocket.SendAsync(response, WebSocketMessageType.Text, true, CancellationToken.None);
+
+                    if (token == "close-after-first-datasync")
+                    {
+                        await webSocket.CloseOutputAsync(
+                            WebSocketCloseStatus.EndpointUnavailable,
+                            "server goes down",
+                            CancellationToken.None
+                        );
+                    }
                 }
             }
             catch


### PR DESCRIPTION
Add `FbClientStatus` to enable health checks of the `FbClient`. This status will indicate whether the `FbClient` is connected and functioning properly. This information can be used for debugging, logging, or alerting purposes.
