### PR TITLE
feat: add DisableEvents option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ await client.CloseAsync();
 
 ### FbClient
 
-The FbClient is the heart of the SDK which providing access to FeatBit server. Applications should instantiate a *
-*single instance** for the lifetime of the application.
+The FbClient is the heart of the SDK which providing access to FeatBit server. Applications should instantiate a **single instance** for the lifetime of the application.
 
 #### FbClient Using Default Options
 
@@ -135,8 +134,7 @@ var client = new FbClient(options);
 We can register the FeatBit services using standard conventions.
 
 > **Note**
-> The `AddFeatBit` extension method will block the current thread for a maximum duration specified
-> in `FbOptions.StartWaitTime`.
+> The `AddFeatBit` extension method will block the current thread for a maximum duration specified in `FbOptions.StartWaitTime`.
 
 ```csharp
 using FeatBit.Sdk.Server.DependencyInjection;
@@ -207,8 +205,7 @@ describing how the value was determined for each type.
 - JsonVariation/JsonVariationDetail (in consideration)
 
 > **Note**
-> Since the current version does not have native support for retrieving JSON variations, you can utilize
-> the `StringVariation` method as an alternative to obtain the JSON string.
+> Since the current version does not have native support for retrieving JSON variations, you can use the `StringVariation` method as an alternative to get the JSON string.
 
 Variation calls take the feature flag key, a FbUser, and a default value. If any error makes it impossible to
 evaluate the flag (for instance, the feature flag key does not match any existing flag), default value is returned.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ a [preview version](https://www.nuget.org/packages/FeatBit.ServerSdk/absoluteLat
 
 ### Prerequisite
 
-Before using the SDK, you need to obtain the environment secret and SDK URLs. 
+Before using the SDK, you need to obtain the environment secret and SDK URLs.
 
 Follow the documentation below to retrieve these values
 
@@ -98,7 +98,8 @@ await client.CloseAsync();
 
 ### FbClient
 
-The FbClient is the heart of the SDK which providing access to FeatBit server. Applications should instantiate a **single instance** for the lifetime of the application.
+The FbClient is the heart of the SDK which providing access to FeatBit server. Applications should instantiate a *
+*single instance** for the lifetime of the application.
 
 #### FbClient Using Default Options
 
@@ -134,7 +135,8 @@ var client = new FbClient(options);
 We can register the FeatBit services using standard conventions.
 
 > **Note**
-> The `AddFeatBit` extension method will block the current thread for a maximum duration specified in `FbOptions.StartWaitTime`.
+> The `AddFeatBit` extension method will block the current thread for a maximum duration specified
+> in `FbOptions.StartWaitTime`.
 
 ```csharp
 using FeatBit.Sdk.Server.DependencyInjection;
@@ -205,7 +207,8 @@ describing how the value was determined for each type.
 - JsonVariation/JsonVariationDetail (in consideration)
 
 > **Note**
-> Since the current version does not have native support for retrieving JSON variations, you can utilize the `StringVariation` method as an alternative to obtain the JSON string.
+> Since the current version does not have native support for retrieving JSON variations, you can utilize
+> the `StringVariation` method as an alternative to obtain the JSON string.
 
 Variation calls take the feature flag key, a FbUser, and a default value. If any error makes it impossible to
 evaluate the flag (for instance, the feature flag key does not match any existing flag), default value is returned.
@@ -247,7 +250,7 @@ var options = new FbOptionsBuilder()
 var client = new FbClient(options);
 ```
 
-When you put the SDK in offline mode, no insight message is sent to the server and all feature flag evaluations return
+When you put the SDK in offline mode, no events are sent to the server and all feature flag evaluations return
 fallback values because there are no feature flags or segments available. If you want to use your own data source in
 this case, the sdk allows users to populate feature flags and segments data from a JSON string. Here is an
 example: [featbit-bootstrap.json](/tests/FeatBit.ServerSdk.Tests/Bootstrapping/featbit-bootstrap.json).
@@ -276,6 +279,20 @@ var options = new FbOptionsBuilder()
     .Build();
 
 var client = new FbClient(options);
+```
+
+### Disable Events Collection
+
+By default, the SDK automatically sends events (flag evaluation events and metric events for A/B testing) to the FeatBit
+server, unless the SDK is in offline mode.
+
+If you prefer to disable this event collection while the SDK is in online mode, you
+can configure this behavior using the `DisableEvents` option.
+
+```csharp
+var options = new FbOptionsBuilder()
+    .DisableEvents(true)
+    .Build();
 ```
 
 ### Experiments (A/B/n Testing)

--- a/src/FeatBit.ServerSdk/FbClient.cs
+++ b/src/FeatBit.ServerSdk/FbClient.cs
@@ -123,10 +123,13 @@ namespace FeatBit.Sdk.Server
             _store = new DefaultMemoryStore();
             _evaluator = new Evaluator(_store);
 
+            _eventProcessor = _options.Offline || _options.DisableEvents
+                ? new NullEventProcessor()
+                : new DefaultEventProcessor(options);
+
             if (_options.Offline)
             {
                 _dataSynchronizer = new NullDataSynchronizer();
-                _eventProcessor = new NullEventProcessor();
 
                 // use bootstrap provider to populate store
                 _options.BootstrapProvider.Populate(_store);
@@ -134,7 +137,6 @@ namespace FeatBit.Sdk.Server
             else
             {
                 _dataSynchronizer = new WebSocketDataSynchronizer(options, _store);
-                _eventProcessor = new DefaultEventProcessor(options);
             }
 
             _logger = options.LoggerFactory.CreateLogger<FbClient>();

--- a/src/FeatBit.ServerSdk/Options/FbOptions.cs
+++ b/src/FeatBit.ServerSdk/Options/FbOptions.cs
@@ -17,7 +17,7 @@ namespace FeatBit.Sdk.Server.Options
         public TimeSpan StartWaitTime { get; set; }
 
         /// <summary>
-        /// Whether or not this client is offline. If true, no calls to FeatBit will be made.
+        /// Whether this client is offline. If true, no calls to FeatBit will be made.
         /// </summary>
         /// <value>Defaults to <c>false</c></value>
         public bool Offline { get; set; }
@@ -29,7 +29,7 @@ namespace FeatBit.Sdk.Server.Options
         internal IBootstrapProvider BootstrapProvider { get; set; }
 
         /// <summary>
-        /// Disables event collection.
+        /// Whether to disable events collections.
         /// </summary>
         public bool DisableEvents { get; set; }
 
@@ -137,6 +137,7 @@ namespace FeatBit.Sdk.Server.Options
         internal FbOptions(
             TimeSpan startWaitTime,
             bool offline,
+            bool disableEvents,
             string envSecret,
             Uri streamingUri,
             Uri eventUri,
@@ -152,11 +153,11 @@ namespace FeatBit.Sdk.Server.Options
             int maxSendEventAttempts,
             TimeSpan sendEventRetryInterval,
             IBootstrapProvider bootstrapProvider,
-            ILoggerFactory loggerFactory,
-            bool disableEvents)
+            ILoggerFactory loggerFactory)
         {
             StartWaitTime = startWaitTime;
             Offline = offline;
+            DisableEvents = disableEvents;
 
             EnvSecret = envSecret;
             StreamingUri = streamingUri;
@@ -177,16 +178,14 @@ namespace FeatBit.Sdk.Server.Options
             BootstrapProvider = bootstrapProvider;
 
             LoggerFactory = loggerFactory;
-
-            DisableEvents = disableEvents;
         }
 
         internal FbOptions ShallowCopy()
         {
-            var newOptions = new FbOptions(StartWaitTime, Offline, EnvSecret, StreamingUri, EventUri, ConnectTimeout,
-                CloseTimeout, KeepAliveInterval, ReconnectRetryDelays, MaxFlushWorker, AutoFlushInterval, FlushTimeout,
-                MaxEventsInQueue, MaxEventPerRequest, MaxSendEventAttempts, SendEventRetryInterval, BootstrapProvider,
-                LoggerFactory, DisableEvents);
+            var newOptions = new FbOptions(StartWaitTime, Offline, DisableEvents, EnvSecret, StreamingUri, EventUri,
+                ConnectTimeout, CloseTimeout, KeepAliveInterval, ReconnectRetryDelays, MaxFlushWorker,
+                AutoFlushInterval, FlushTimeout, MaxEventsInQueue, MaxEventPerRequest, MaxSendEventAttempts,
+                SendEventRetryInterval, BootstrapProvider, LoggerFactory);
 
             return newOptions;
         }

--- a/src/FeatBit.ServerSdk/Options/FbOptions.cs
+++ b/src/FeatBit.ServerSdk/Options/FbOptions.cs
@@ -29,6 +29,11 @@ namespace FeatBit.Sdk.Server.Options
         internal IBootstrapProvider BootstrapProvider { get; set; }
 
         /// <summary>
+        /// Disables event collection.
+        /// </summary>
+        public bool DisableEvents { get; set; }
+
+        /// <summary>
         /// The SDK key for your FeatBit environment.
         /// </summary>
         public string EnvSecret { get; set; }
@@ -147,7 +152,8 @@ namespace FeatBit.Sdk.Server.Options
             int maxSendEventAttempts,
             TimeSpan sendEventRetryInterval,
             IBootstrapProvider bootstrapProvider,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            bool disableEvents)
         {
             StartWaitTime = startWaitTime;
             Offline = offline;
@@ -171,6 +177,8 @@ namespace FeatBit.Sdk.Server.Options
             BootstrapProvider = bootstrapProvider;
 
             LoggerFactory = loggerFactory;
+
+            DisableEvents = disableEvents;
         }
 
         internal FbOptions ShallowCopy()
@@ -178,7 +186,7 @@ namespace FeatBit.Sdk.Server.Options
             var newOptions = new FbOptions(StartWaitTime, Offline, EnvSecret, StreamingUri, EventUri, ConnectTimeout,
                 CloseTimeout, KeepAliveInterval, ReconnectRetryDelays, MaxFlushWorker, AutoFlushInterval, FlushTimeout,
                 MaxEventsInQueue, MaxEventPerRequest, MaxSendEventAttempts, SendEventRetryInterval, BootstrapProvider,
-                LoggerFactory);
+                LoggerFactory, DisableEvents);
 
             return newOptions;
         }

--- a/src/FeatBit.ServerSdk/Options/FbOptions.cs
+++ b/src/FeatBit.ServerSdk/Options/FbOptions.cs
@@ -29,7 +29,7 @@ namespace FeatBit.Sdk.Server.Options
         internal IBootstrapProvider BootstrapProvider { get; set; }
 
         /// <summary>
-        /// Whether to disable events collections.
+        /// Whether to disable events collection.
         /// </summary>
         public bool DisableEvents { get; set; }
 

--- a/src/FeatBit.ServerSdk/Options/FbOptionsBuilder.cs
+++ b/src/FeatBit.ServerSdk/Options/FbOptionsBuilder.cs
@@ -72,10 +72,10 @@ namespace FeatBit.Sdk.Server.Options
 
         public FbOptions Build()
         {
-            return new FbOptions(_startWaitTime, _offline, _envSecret, _streamingUri, _eventUri, _connectTimeout,
-                _closeTimeout, _keepAliveInterval, _reconnectRetryDelays, _maxFlushWorker, _autoFlushInterval,
-                _flushTimeout, _maxEventsInQueue, _maxEventPerRequest, _maxSendEventAttempts, _sendEventRetryInterval,
-                _bootstrapProvider, _loggerFactory, _disableEvents);
+            return new FbOptions(_startWaitTime, _offline, _disableEvents, _envSecret, _streamingUri, _eventUri,
+                _connectTimeout, _closeTimeout, _keepAliveInterval, _reconnectRetryDelays, _maxFlushWorker,
+                _autoFlushInterval, _flushTimeout, _maxEventsInQueue, _maxEventPerRequest, _maxSendEventAttempts,
+                _sendEventRetryInterval, _bootstrapProvider, _loggerFactory);
         }
 
         public FbOptionsBuilder StartWaitTime(TimeSpan timeout)

--- a/src/FeatBit.ServerSdk/Options/FbOptionsBuilder.cs
+++ b/src/FeatBit.ServerSdk/Options/FbOptionsBuilder.cs
@@ -10,6 +10,7 @@ namespace FeatBit.Sdk.Server.Options
     {
         private TimeSpan _startWaitTime;
         private bool _offline;
+        private bool _disableEvents;
 
         private readonly string _envSecret;
 
@@ -41,6 +42,7 @@ namespace FeatBit.Sdk.Server.Options
         {
             _startWaitTime = TimeSpan.FromSeconds(5);
             _offline = false;
+            _disableEvents = false;
 
             _envSecret = envSecret;
 
@@ -73,7 +75,7 @@ namespace FeatBit.Sdk.Server.Options
             return new FbOptions(_startWaitTime, _offline, _envSecret, _streamingUri, _eventUri, _connectTimeout,
                 _closeTimeout, _keepAliveInterval, _reconnectRetryDelays, _maxFlushWorker, _autoFlushInterval,
                 _flushTimeout, _maxEventsInQueue, _maxEventPerRequest, _maxSendEventAttempts, _sendEventRetryInterval,
-                _bootstrapProvider, _loggerFactory);
+                _bootstrapProvider, _loggerFactory, _disableEvents);
         }
 
         public FbOptionsBuilder StartWaitTime(TimeSpan timeout)
@@ -119,6 +121,12 @@ namespace FeatBit.Sdk.Server.Options
         public FbOptionsBuilder CloseTimeout(TimeSpan timeout)
         {
             _closeTimeout = timeout;
+            return this;
+        }
+
+        public FbOptionsBuilder DisableEvents(bool disableEvents)
+        {
+            _disableEvents = disableEvents;
             return this;
         }
 

--- a/tests/FeatBit.ServerSdk.Tests/FbClientOfflineTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/FbClientOfflineTests.cs
@@ -20,7 +20,7 @@ public class FbClientOfflineTests
     }
 
     [Fact]
-    public void UseNullEventProcessor()
+    public void UseNullDataSource()
     {
         var options = new FbOptionsBuilder()
             .Offline(true)
@@ -32,10 +32,23 @@ public class FbClientOfflineTests
     }
 
     [Fact]
-    public void UseNullDataSource()
+    public void UseNullEventProcessor()
     {
         var options = new FbOptionsBuilder()
             .Offline(true)
+            .Build();
+
+        var client = new FbClient(options);
+
+        Assert.IsType<NullEventProcessor>(client._eventProcessor);
+    }
+
+    [Fact]
+    public void UseNullEventProcessorWhenEventsAreDisabled()
+    {
+        var options = new FbOptionsBuilder()
+            .Offline(false)
+            .DisableEvents(true)
             .Build();
 
         var client = new FbClient(options);

--- a/tests/FeatBit.ServerSdk.Tests/Options/FbOptionsBuilderTests.HasDefaultValues.verified.txt
+++ b/tests/FeatBit.ServerSdk.Tests/Options/FbOptionsBuilderTests.HasDefaultValues.verified.txt
@@ -1,6 +1,7 @@
 ﻿{
   StartWaitTime: 00:00:05,
   Offline: false,
+  DisableEvents: false,
   EnvSecret: secret,
   StreamingUri: ws://localhost:5100,
   EventUri: http://localhost:5100,


### PR DESCRIPTION
Adds an option to disable event collection but keep data synchronisation, defaulting to the current behaviour of both online.

Also fixes some incorrect test names.

resolves #20