### PR TITLE
fix: always use ConnectTimeout when connecting the WebSocket

### DIFF
--- a/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
@@ -3,7 +3,6 @@ using System.Buffers;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using FeatBit.Sdk.Server.Concurrent;
 using FeatBit.Sdk.Server.Options;
@@ -69,8 +68,7 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
         {
             Task.Run(() =>
             {
-                var cts = new CancellationTokenSource(_options.ConnectTimeout);
-                return _webSocket.ConnectAsync(cts.Token);
+                return _webSocket.ConnectAsync();
             });
 
             return _initTcs.Task;

--- a/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
+++ b/src/FeatBit.ServerSdk/DataSynchronizer/WebSocketDataSynchronizer.cs
@@ -66,10 +66,7 @@ namespace FeatBit.Sdk.Server.DataSynchronizer
 
         public Task<bool> StartAsync()
         {
-            Task.Run(() =>
-            {
-                return _webSocket.ConnectAsync();
-            });
+            Task.Run(() => _webSocket.ConnectAsync());
 
             return _initTcs.Task;
         }

--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
@@ -24,7 +24,7 @@ namespace FeatBit.Sdk.Server.Transport
             new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("{\"messageType\":\"ping\",\"data\":{}}"));
 
         private readonly FbOptions _options;
-        private readonly Func<WebSocketTransport> _transportFactory;
+        private readonly Func<FbOptions, WebSocketTransport> _transportFactory;
         private readonly Func<FbOptions, Uri> _webSocketUriResolver;
         private WebSocketTransport _transport;
         private Task _receiveTask;
@@ -38,7 +38,7 @@ namespace FeatBit.Sdk.Server.Transport
 
         internal FbWebSocket(
             FbOptions options,
-            Func<WebSocketTransport> transportFactory = null,
+            Func<FbOptions, WebSocketTransport> transportFactory = null,
             Func<FbOptions, Uri> webSocketUriResolver = null)
         {
             _options = options;
@@ -64,7 +64,7 @@ namespace FeatBit.Sdk.Server.Transport
             }
 
             var transportFactory = _transportFactory ?? DefaultWebSocketTransportFactory;
-            var transport = transportFactory();
+            var transport = transportFactory(_options);
             if (transport == null)
             {
                 throw new InvalidOperationException("Configured WebSocketTransportFactory did not return a value.");
@@ -108,9 +108,9 @@ namespace FeatBit.Sdk.Server.Transport
             Log.Started(_logger);
         }
 
-        private WebSocketTransport DefaultWebSocketTransportFactory()
+        private WebSocketTransport DefaultWebSocketTransportFactory(FbOptions options)
         {
-            return new WebSocketTransport(_loggerFactory);
+            return new WebSocketTransport(options, _loggerFactory);
         }
 
         private static Uri DefaultWebSocketUriResolver(FbOptions options)

--- a/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
+++ b/src/FeatBit.ServerSdk/Transport/FbWebSocket.cs
@@ -52,7 +52,7 @@ namespace FeatBit.Sdk.Server.Transport
             _logger = _loggerFactory.CreateLogger<FbWebSocket>();
         }
 
-        public async Task ConnectAsync(CancellationToken cancellationToken = default, bool isReconnecting = false)
+        public async Task ConnectAsync(bool isReconnecting = false, CancellationToken cancellationToken = default)
         {
             Log.Starting(_logger);
 
@@ -75,7 +75,7 @@ namespace FeatBit.Sdk.Server.Transport
             {
                 // starts the transport
                 Log.StartingTransport(_logger, "WebSockets", webSocketUri);
-                await transport.StartAsync(webSocketUri, _options.CloseTimeout, cancellationToken);
+                await transport.StartAsync(webSocketUri, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -254,7 +254,7 @@ namespace FeatBit.Sdk.Server.Transport
 
                 try
                 {
-                    await ConnectAsync(_stopCts.Token, isReconnecting: true).ConfigureAwait(false);
+                    await ConnectAsync(isReconnecting: true, _stopCts.Token).ConfigureAwait(false);
 
                     Log.Reconnected(_logger, retryTimes, DateTime.UtcNow - reconnectStartTime);
 

--- a/src/FeatBit.ServerSdk/Transport/WebSocketTransport.cs
+++ b/src/FeatBit.ServerSdk/Transport/WebSocketTransport.cs
@@ -112,9 +112,15 @@ namespace FeatBit.Sdk.Server.Transport
                 cts.CancelAfter(_options.ConnectTimeout);
                 await webSocket.ConnectAsync(uri, cts.Token);
             }
-            catch
+            catch (Exception ex)
             {
                 webSocket.Dispose();
+
+                if (ex is OperationCanceledException && !cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException("Connect timed out.", ex);
+                }
+
                 throw;
             }
 

--- a/tests/FeatBit.ServerSdk.Tests/TestApp.cs
+++ b/tests/FeatBit.ServerSdk.Tests/TestApp.cs
@@ -22,11 +22,12 @@ public class TestApp : WebApplicationFactory<TestStartup>
         return wsUri;
     }
 
-    internal WebSocketTransport CreateWebSocketTransport()
+    internal WebSocketTransport CreateWebSocketTransport(FbOptions options)
     {
         var client = Server.CreateWebSocketClient();
 
         return new WebSocketTransport(
+            options,
             webSocketFactory: (uri, cancellationToken) => client.ConnectAsync(uri, cancellationToken)
         );
     }

--- a/tests/FeatBit.ServerSdk.Tests/Transport/WebSocketsTransportTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/Transport/WebSocketsTransportTests.cs
@@ -1,6 +1,8 @@
 using System.Net.WebSockets;
 using System.Text;
 
+using FeatBit.Sdk.Server.Options;
+
 namespace FeatBit.Sdk.Server.Transport;
 
 [Collection(nameof(TestApp))]
@@ -16,7 +18,8 @@ public class WebSocketsTransportTests
     [Fact]
     public async Task StartAndStopAsync()
     {
-        var transport = _app.CreateWebSocketTransport();
+        var options = new FbOptionsBuilder().Build();
+        var transport = _app.CreateWebSocketTransport(options);
         var uri = _app.GetWsUri("echo");
 
         await transport.StartAsync(uri);
@@ -32,7 +35,8 @@ public class WebSocketsTransportTests
     [Fact]
     public async Task SendReceiveAsync()
     {
-        var transport = _app.CreateWebSocketTransport();
+        var options = new FbOptionsBuilder().Build();
+        var transport = _app.CreateWebSocketTransport(options);
         var uri = _app.GetWsUri("echo");
 
         await transport.StartAsync(uri);

--- a/tests/FeatBit.ServerSdk.Tests/Transport/WebSocketsTransportTests.cs
+++ b/tests/FeatBit.ServerSdk.Tests/Transport/WebSocketsTransportTests.cs
@@ -61,4 +61,16 @@ public class WebSocketsTransportTests
 
         await transport.StopAsync();
     }
+
+    [Fact]
+    public async Task StartAsyncShouldThrowTimeoutExceptionWhenConnectTimesOut()
+    {
+        var options = new FbOptionsBuilder()
+            .ConnectTimeout(TimeSpan.FromTicks(1))
+            .Build();
+        var transport = new WebSocketTransport(options);
+        var uri = _app.GetWsUri("echo");
+
+        await Assert.ThrowsAsync<TimeoutException>(() => transport.StartAsync(uri));
+    }
 }


### PR DESCRIPTION
Change all connection attempts to use the configured `ConnectTimeout`, including reconnect attempts.

Fixes https://github.com/featbit/featbit-dotnet-sdk/issues/26